### PR TITLE
Add toolbox autoinstall to survive esd update.

### DIFF
--- a/cpu/onlineservices/1/default/tsd/etc/persistence/esd/mibstd2-tools.esd
+++ b/cpu/onlineservices/1/default/tsd/etc/persistence/esd/mibstd2-tools.esd
@@ -181,3 +181,31 @@ keyValue
 script
 	value 	sys 1 0x0100 "/tsd/etc/persistence/esd/scripts/util_reboot.sh"
 	label 	"Reboot unit"
+
+keyValue
+	value 	String sys 0x00000000 0
+	label 	""
+	poll 	0
+
+keyValue
+	value 	String sys 0x00000000 0
+	label 	"--- Auto-install from SD on startup ---"
+	poll 	0
+
+keyValue
+	value 	String sys 0x00000000 0
+	label 	"Reinstalls toolbox from SD card automatically after ESD update."
+	poll 	0
+
+keyValue
+	value 	String sys 0x00000000 0
+	label 	"SD card with toolbox must be inserted on first boot after update."
+	poll 	0
+
+script
+	value 	sys 1 0x0100 "/tsd/etc/persistence/esd/scripts/activate_auto_install.sh"
+	label 	"Activate auto-install on startup"
+
+script
+	value 	sys 1 0x0100 "/tsd/etc/persistence/esd/scripts/deactivate_auto_install.sh"
+	label 	"Deactivate auto-install on startup"

--- a/cpu/onlineservices/1/default/tsd/etc/persistence/esd/scripts/activate_auto_install.sh
+++ b/cpu/onlineservices/1/default/tsd/etc/persistence/esd/scripts/activate_auto_install.sh
@@ -1,0 +1,39 @@
+#!/bin/ksh
+echo "This script activates auto-installation of toolbox from SD card on startup"
+echo
+
+HELPER=/tsd/var/toolbox_autoinstall.sh
+MARKER="TOOLBOX_AUTOINSTALL"
+STARTUP=/tsd/bin/system/startup
+
+# Mount system as read/write
+. /tsd/etc/persistence/esd/scripts/util_mount.sh
+
+# Write helper script to /tsd/var/ (survives ESD update)
+echo "Writing helper script to $HELPER..."
+echo '#!/bin/ksh' > $HELPER
+echo 'sleep 15' >> $HELPER
+echo '[ -f /tsd/etc/persistence/esd/scripts/util_update.sh ] && exit 0' >> $HELPER
+echo 'for i in /media/mp00* /fs/* /mnt/*; do' >> $HELPER
+echo '    [ -d "$i" ] || continue' >> $HELPER
+echo '    if [ -f "$i/install.sh" ]; then' >> $HELPER
+echo '        ksh $i/install.sh' >> $HELPER
+echo '        exit 0' >> $HELPER
+echo '    fi' >> $HELPER
+echo 'done' >> $HELPER
+chmod 777 $HELPER
+echo "Done."
+
+# Remove any existing hook (idempotency) and append new one
+sed "/$MARKER/d" $STARTUP > /tmp/startup.tmp
+mv -f /tmp/startup.tmp $STARTUP && chmod 777 $STARTUP
+echo "[ -f $HELPER ] && ksh $HELPER & # $MARKER" >> $STARTUP
+echo "Startup hook injected."
+
+# Mount system as read/only
+. /tsd/etc/persistence/esd/scripts/util_mount_ro.sh
+
+echo
+echo "Auto-install is activated."
+echo "On next boot, toolbox will be reinstalled from SD card if missing (approx. 2 minutes after boot)."
+exit 0

--- a/cpu/onlineservices/1/default/tsd/etc/persistence/esd/scripts/deactivate_auto_install.sh
+++ b/cpu/onlineservices/1/default/tsd/etc/persistence/esd/scripts/deactivate_auto_install.sh
@@ -1,0 +1,26 @@
+#!/bin/ksh
+echo "This script deactivates auto-installation of toolbox from SD card on startup"
+echo
+
+HELPER=/tsd/var/toolbox_autoinstall.sh
+MARKER="TOOLBOX_AUTOINSTALL"
+STARTUP=/tsd/bin/system/startup
+
+# Mount system as read/write
+. /tsd/etc/persistence/esd/scripts/util_mount.sh
+
+# Remove hook from startup
+sed "/$MARKER/d" $STARTUP > /tmp/startup.tmp
+mv -f /tmp/startup.tmp $STARTUP && chmod 777 $STARTUP
+echo "Startup hook removed."
+
+# Remove helper script
+rm -f $HELPER
+echo "Helper script removed."
+
+# Mount system as read/only
+. /tsd/etc/persistence/esd/scripts/util_mount_ro.sh
+
+echo
+echo "Auto-install is deactivated."
+exit 0


### PR DESCRIPTION
When the MIB unit receives an `esd` update, the toolbox folder is wiped. Previously, the user had to manually reinstall the toolbox (for example, via DUB-E100 + telnet: https://onxblog.com/cars/980/) after an `esd` update, which could be a real pain.

This PR adds two new Tools menu entries that allow the user to activate/deactivate automatic toolbox reinstallation on next boot after an `esd` update.

How it works:
- activate_auto_install.sh writes a small helper script to `/tsd/var/toolbox_autoinstall.sh` (which should survive`esd` update) and injects a hook into the startup script (just like `acrivate_perm_access.sh` is doing).
- On next boot, the hook checks if the toolbox `esd` scripts are missing (checking specifically `/tsd/etc/persistence/esd/scripts/util_update.sh`) - if so, it looks for `install.sh` on any mounted SD card/USB drive and runs it automatically re-installing the toolbox.
- deactivate_auto_install.sh removes both the hook and the helper script

Successfully tested on my `5Q0035840A` during 253 → 480 upgrade. 

This PR introduces a great new way to get rid of the annoying 1556 error caused by esd version mismatch:
```
Mar 02 16:36:46.426 5 10014 2 [00340004] [iMX6.Itr.itr.sysconfig] 23 49214 errors: 
SW incompatible one incompatible module: cpuplus/esd%2 current version 2243011 planed version 4478011
```