### PR TITLE
Added support for MUTE->APP for MST2_EU_VW_PQ_P0480T

### DIFF
--- a/cpu/onlineservices/1/default/hashes.txt
+++ b/cpu/onlineservices/1/default/hashes.txt
@@ -395,8 +395,8 @@ FileSize = "1470"
 Checksum = "b8e87fff7397295958219a3825726ed4a9ab223e"
 
 FileName = "/tsd/etc/persistence/esd/scripts/rb_traffic2app.sh"
-FileSize = "1999"
-Checksum = "5ac1eaec94494acdefcb870245f21eb256d1c961"
+FileSize = "2067"
+Checksum = "e09e088f7f056f6c2c97f935946c1b8a2b002c07"
 
 FileName = "/tsd/etc/persistence/esd/scripts/rb_voice2app.sh"
 FileSize = "1545"

--- a/cpu/onlineservices/1/default/hashes.txt
+++ b/cpu/onlineservices/1/default/hashes.txt
@@ -379,8 +379,8 @@ FileSize = "1408"
 Checksum = "ea736bca861c42020646c573c4a9934127592ee2"
 
 FileName = "/tsd/etc/persistence/esd/scripts/rb_mute2app.sh"
-FileSize = "1612"
-Checksum = "f95cb0877b103954e24ec465e495d0f69dead694"
+FileSize = "1680"
+Checksum = "462748e42dcd4289a099ec7186ba280dd02dc78d"
 
 FileName = "/tsd/etc/persistence/esd/scripts/rb_setup2app.sh"
 FileSize = "1546"

--- a/cpu/onlineservices/1/default/tsd/etc/persistence/esd/scripts/rb_mute2app.sh
+++ b/cpu/onlineservices/1/default/tsd/etc/persistence/esd/scripts/rb_mute2app.sh
@@ -30,6 +30,8 @@ case $size in
 		set -A offsets 8B5C 8D5C ;;
 	78200) #MST2_EU_VW_PQ_R0604T cpuplus
 		set -A offsets A930 AB30 ;;
+	67656) #MST2_EU_VW_PQ_P0480T cpuplus
+		set -A offsets 89DE 8BDE ;;
 esac
 
 if [ -n "$offsets" ]; then

--- a/cpu/onlineservices/1/default/tsd/etc/persistence/esd/scripts/rb_traffic2app.sh
+++ b/cpu/onlineservices/1/default/tsd/etc/persistence/esd/scripts/rb_traffic2app.sh
@@ -42,6 +42,8 @@ case $size in
 		set -A offsets A44E AB32 ;;
 	78254) #MST2_EU_VW_ZR_P0515/516T cpu
 		set -A offsets A482 AB66 ;;
+	67854) #MST2_EU_SK_ZR_P0480T cpuplus
+		set -A offsets 85C0 8CA4 ;;
 esac
 
 if [ -n "$offsets" ]; then

--- a/toolbox/gem/cpu/onlineservices/1/default/hashes.txt
+++ b/toolbox/gem/cpu/onlineservices/1/default/hashes.txt
@@ -391,8 +391,8 @@ FileSize = "1408"
 Checksum = "ea736bca861c42020646c573c4a9934127592ee2"
 
 FileName = "/tsd/etc/persistence/esd/scripts/rb_mute2app.sh"
-FileSize = "1612"
-Checksum = "f95cb0877b103954e24ec465e495d0f69dead694"
+FileSize = "1680"
+Checksum = "462748e42dcd4289a099ec7186ba280dd02dc78d"
 
 FileName = "/tsd/etc/persistence/esd/scripts/rb_setup2app.sh"
 FileSize = "1546"

--- a/toolbox/gem/cpu/onlineservices/1/default/hashes.txt
+++ b/toolbox/gem/cpu/onlineservices/1/default/hashes.txt
@@ -407,8 +407,8 @@ FileSize = "1470"
 Checksum = "b8e87fff7397295958219a3825726ed4a9ab223e"
 
 FileName = "/tsd/etc/persistence/esd/scripts/rb_traffic2app.sh"
-FileSize = "1999"
-Checksum = "5ac1eaec94494acdefcb870245f21eb256d1c961"
+FileSize = "2067"
+Checksum = "e09e088f7f056f6c2c97f935946c1b8a2b002c07"
 
 FileName = "/tsd/etc/persistence/esd/scripts/rb_voice2app.sh"
 FileSize = "1545"

--- a/toolbox/gem/cpu/onlineservices/1/default/tsd/etc/persistence/esd/scripts/rb_mute2app.sh
+++ b/toolbox/gem/cpu/onlineservices/1/default/tsd/etc/persistence/esd/scripts/rb_mute2app.sh
@@ -30,6 +30,8 @@ case $size in
 		set -A offsets 8B5C 8D5C ;;
 	78200) #MST2_EU_VW_PQ_R0604T cpuplus
 		set -A offsets A930 AB30 ;;
+	67656) #MST2_EU_VW_PQ_P0480T cpuplus
+		set -A offsets 89DE 8BDE ;;
 esac
 
 if [ -n "$offsets" ]; then

--- a/toolbox/gem/cpu/onlineservices/1/default/tsd/etc/persistence/esd/scripts/rb_traffic2app.sh
+++ b/toolbox/gem/cpu/onlineservices/1/default/tsd/etc/persistence/esd/scripts/rb_traffic2app.sh
@@ -42,6 +42,8 @@ case $size in
 		set -A offsets A44E AB32 ;;
 	78254) #MST2_EU_VW_ZR_P0515/516T cpu
 		set -A offsets A482 AB66 ;;
+	67854) #MST2_EU_SK_ZR_P0480T cpuplus
+		set -A offsets 85C0 8CA4 ;;
 esac
 
 if [ -n "$offsets" ]; then


### PR DESCRIPTION
Initial request: https://github.com/olli991/mib-std2-pq-zr-toolbox/issues/626

Parsed configurationmanager.res:

```
> grep 'KeyID.*MUTE' ./configurationmanager.log
KeyID:0x58 MUTE                                                           0x89DE

> grep 'KeyID.*APP' ./configurationmanager.log
KeyID:0x72 APP/SMARTPHONE                                                 0x8BDE

> stat -f %z configurationmanager.res 
67656
```